### PR TITLE
수정: 카테고리 사이드바 본문 침범 버그 해결

### DIFF
--- a/docs/_posts/개발/개발이야기/2026-02-01-블로그 UI-UX 개선기.md
+++ b/docs/_posts/개발/개발이야기/2026-02-01-블로그 UI-UX 개선기.md
@@ -117,6 +117,7 @@ window.addEventListener('resize', updateSidebarPositions);
 
 기존에는 `front.html`, `category.html`, 각 포스트 레이아웃마다 카테고리 목록을 따로 정의하고 있었습니다. 필터링 기준도 제각각이었습니다. 이를 `_includes/category-sidebar.html`로 통합했습니다.
 
+{% raw %}
 ```html
 <aside id="category-list" aria-label="Category List">
   <h2>Categories</h2>
@@ -144,8 +145,9 @@ window.addEventListener('resize', updateSidebarPositions);
   </details>
 </aside>
 ```
+{% endraw %}
 
-주요 카테고리는 바로 보이고, 자주 안 보는 카테고리는 "더 보기" 서랍 안에 넣었습니다. 이제 모든 레이아웃에서 `{% include category-sidebar.html %}`만 호출하면 됩니다.
+주요 카테고리는 바로 보이고, 자주 안 보는 카테고리는 "더 보기" 서랍 안에 넣었습니다. 이제 모든 레이아웃에서 {% raw %}`{% include category-sidebar.html %}`{% endraw %}만 호출하면 됩니다.
 
 ### 포스트 네비게이션 카드 스타일
 

--- a/docs/javascripts/headerLinkScroller.js
+++ b/docs/javascripts/headerLinkScroller.js
@@ -2,6 +2,14 @@
 // 사이드바(목차, 카테고리)를 본문 영역 기준으로 동적 배치
 
 (function() {
+    // === 레이아웃 상수 정의 ===
+    var SIDEBAR_WIDTH = 180;           // 카테고리 사이드바 CSS 너비
+    var SIDEBAR_PADDING = 32;          // padding: 1em * 2
+    var SIDEBAR_BORDER = 2;            // border: 1px * 2
+    var SIDEBAR_TOTAL_WIDTH = SIDEBAR_WIDTH + SIDEBAR_PADDING + SIDEBAR_BORDER; // 214px
+    var MIN_GAP = 20;                  // 본문과 사이드바 최소 간격
+    var MIN_LEFT_MARGIN = 10;          // 화면 왼쪽 끝 최소 간격
+
     var headerLinks = document.getElementById('header-links');
     var headerLinksToggler = document.getElementById('header-links-toggler');
     var categoryList = document.getElementById('category-list');
@@ -49,12 +57,19 @@
 
         // 카테고리 사이드바 - 본문 왼쪽에 배치
         if (categoryList) {
-            var leftPosition = rect.left - 200;
-            // 화면 왼쪽 끝을 넘지 않도록
-            if (leftPosition < 10) {
+            // 사이드바가 필요로 하는 최소 공간 계산
+            var requiredSpace = SIDEBAR_TOTAL_WIDTH + MIN_GAP + MIN_LEFT_MARGIN;
+
+            // 공간 부족 시 숨김 처리
+            if (rect.left < requiredSpace) {
                 categoryList.style.visibility = 'hidden';
+                categoryList.style.pointerEvents = 'none';
             } else {
+                // 사이드바 오른쪽 끝이 본문에서 MIN_GAP만큼 떨어지도록 배치
+                var leftPosition = rect.left - MIN_GAP - SIDEBAR_TOTAL_WIDTH;
+
                 categoryList.style.visibility = '';
+                categoryList.style.pointerEvents = '';
                 categoryList.style.left = leftPosition + 'px';
                 categoryList.style.top = topValue + 'px';
             }


### PR DESCRIPTION
프롬프트: 오른쪽 목차에서 글 선택 시 카테고리 메뉴가 글을 가리는 버그 점검 및 해결

변경 내용:
- headerLinkScroller.js: 사이드바 위치 계산 로직 개선
  - 사이드바 전체 너비(214px) 기반 정확한 위치 계산
  - 본문과 사이드바 사이 최소 20px 간격 보장
  - pointer-events 처리 추가
- 블로그 UI-UX 개선기.md: Liquid 태그 이스케이프 추가
  - {% raw %}{% endraw %}로 코드 블록 내 Liquid 태그 보호
  - 중복 사이드바 렌더링 방지